### PR TITLE
Fix Podspec for iOS

### DIFF
--- a/react-native-datalogic-module.podspec
+++ b/react-native-datalogic-module.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = "@datalogic/react-native-datalogic-module"
+  s.name         = "react-native-datalogic-module"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]
@@ -11,11 +11,9 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "9.0" }
-  s.source       = { :git => "https://datalogic.github.io/.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/datalogic/react-native-datalogic-module.git", :tag => "#{s.version}" }
 
-  
   s.source_files = "ios/**/*.{h,m,mm}"
-  
 
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
The current Podspec returns the following error when attempting to auto-link on iOS:
```
$ expo run:ios
⚠️  Something went wrong running `pod install` in the `ios` directory.
Command `pod install` failed.
└─ Cause: No podspec found for `@datalogic` in `../node_modules/@datalogic/react-native-datalogic-module`
```
```
$ pod install
Using Expo modules
Auto-linking React Native modules for target `XXX`: @datalogic/react-native-datalogic-module, RNCMaskedView, RNGestureHandler, RNReanimated, RNScreens, and react-native-safe-area-context
Analyzing dependencies
[!] No podspec found for `@datalogic` in `../node_modules/@datalogic/react-native-datalogic-module`
```